### PR TITLE
Added the DeserializeWithoutHttpContentAsync to the HttpContentSerial…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * **[Breaking]** Renamed `HttpContentSerializer.DeserializeCore` to `DeserializeAsyncCore`.
 * **[Breaking]** Renamed `SetContent(byte[], ...)` to `SetByteArrayContent`.
 * **[Breaking]** Renamed `SetContent(string, ...)` to `SetStringContent`.
+* Added the `DeserializeWithoutHttpContentAsync` method to the `HttpContentSerializer` to allow changing the default deserialization behavior if no HttpContent is given.
 * Added new `SetContent(IHttpContentSerializer, ...)` overloads to the `HttpContentBuilderExtensions`.
 * Several methods like `ApiResponse{T}.DeserializeResourceAsync` now support an additional `CancellationToken` parameter.
 * Annotated the library with .NET's new nullable attributes. The `netstandard2.0` target uses a polyfill (via the `Nullable` NuGet package), while `netstandard2.1` uses .NET's default attributes.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -14,7 +14,7 @@
     <NeutralLanguage>en</NeutralLanguage>
 
     <VersionPrefix>0.6.0</VersionPrefix>
-    <VersionSuffix>alpha1</VersionSuffix>
+    <VersionSuffix>alpha2</VersionSuffix>
     <Product>ReqRest</Product>
     <Authors>Manuel Römer</Authors>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/ReqRest/Internal/Serializers/SpecificHttpContentDeserializer.cs
+++ b/src/ReqRest/Internal/Serializers/SpecificHttpContentDeserializer.cs
@@ -29,9 +29,12 @@
 
             if (contentType != typeof(T))
             {
-                throw new NotSupportedException(ExceptionStrings.Serializer_CanOnlyDeserialize(typeof(string)));
+                throw new NotSupportedException(ExceptionStrings.SpecificHttpContentSerializer_CanOnlyDeserialize(typeof(string)));
             }
 
+            // This class is only inherited by primitive serializers (e.g. string, byte[], ...).
+            // For these, it doesn't make sense to throw an exception here, because 'null' is basically
+            // equal to 'empty' here.
             if (httpContent is null)
             {
                 return DefaultValue;

--- a/src/ReqRest/Resources/ExceptionStrings.cs
+++ b/src/ReqRest/Resources/ExceptionStrings.cs
@@ -3,7 +3,9 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using ReqRest.Builders;
     using ReqRest.Http;
+    using ReqRest.Serializers;
 
     /// <summary>
     ///     Provides static methods which return exception message strings for the various exceptions
@@ -18,18 +20,20 @@
         #region ReqRest
 
         public static string ApiResponse_InvalidResponseDeserializer() =>
-            "The IHttpContentDeserializer factory for the current response type returned null " +
-            "instead of a deserializer instance.";
+            $"The {nameof(IHttpContentDeserializer)} factory for the current response type returned " +
+            $"null (Nothing in VB) instead of an actual deserializer instance.";
 
         public static string ApiResponse_NoResponseTypeInfoForResponse() =>
-            $"The response had a status code which was not configured. " +
-            $"When building a request via the ApiRequest API, ensure that you declare a possible " +
+            $"The response had a status code which has not been declared before. " +
+            $"When building a request via the {nameof(ApiRequest)} API, ensure that you declare a possible " +
             $"response for this status code via the \"{nameof(ApiRequest.Receive)}\" methods, " +
-            $"so that a response to the request knows which type to deserialize for the given status code.";
+            $"so that a response to the request knows which type should be deserialized for the given status code.";
 
         public static string HttpClientProvider_Returned_Null() =>
-            "The configured HttpClient provider function returned null. " +
-            "Ensure that the function returns a valid HttpClient instance.";
+            $"The configured HttpClient provider function returned null (Nothing in VB). " +
+            $"If you are seeing this exception while using a {nameof(RestClient)}, you can most " +
+            $"likely fix this error by setting the {nameof(RestClientConfiguration)}.{nameof(RestClientConfiguration.HttpClientProvider)} " +
+            $"property to a function which returns an actual HttpClient instance.";
 
         public static string ResponseTypeInfo_MustProvideAtLeastOneStatusCode() =>
             "At least one status code or status code range must be provided.";
@@ -50,15 +54,21 @@
                 $"{conflictingStr}";
         }
 
-        public static string Serializer_CanOnlyDeserialize(Type type) =>
-            $"The serializer can only deserialize objects of type {type.FullName}.";
+        #endregion
+
+        #region ReqRest.Internal
+
+        public static string SpecificHttpContentSerializer_CanOnlyDeserialize(Type type) =>
+            $"The serializer can only deserialize objects of type \"{type.FullName}\".";
 
         #endregion
 
         #region ReqRest.Builders
 
         public static string HttpContentBuilderExtensions_NoHttpContentHeaders() =>
-            "Cannot interact with the content headers, because the HttpContent which is being built is null.";
+            $"The headers of the HttpContent cannot be configured, because the HttpContent is " +
+            $"null (Nothing in VB). Ensure that the {nameof(IHttpContentBuilder.Content)} property " +
+            $"is set to an actual HttpContent instance.";
 
         #endregion
 
@@ -73,14 +83,21 @@
         #region ReqRest.Serializers
 
         public static string HttpContentSerializationException_Message() =>
-            "The (de-)serialization failed because of an unknown error. See the inner exception for details (if available).";
+            "The (de-)serialization failed because of an arbitrary error. This most likely happened, " +
+            "because an inner serializer failed to (de-)serialize the given data. " +
+            "See the inner exception for details (if available).";
 
         public static string HttpContentSerializer_ContentTypeDoesNotMatchActualType(Type expected, Type actual) =>
             $"The content to be serialized does not match the specified type. " +
-            $"Expected an instance of the class ${expected.FullName}, but got {actual.FullName}.";
+            $"Expected an instance of the class \"${expected.FullName}\", but got \"{actual.FullName}\".";
 
-        public static string HttpContentSerializer_HttpContentIsNullButShouldNotBeNoContent(Type type) =>
-            $"Cannot deserialize the type \"{type.FullName}\" because the HTTP response had no content.";
+        public static string HttpContentSerializer_HttpContentIsNull(Type contentType) =>
+            $"The HttpContent to be deserialized into an object of type \"{contentType.FullName}\" " +
+            $"was null (Nothing in VB). An HttpContent which is null cannot be deserialized by this " +
+            $"serializer.\n" +
+            $"If you know that the HttpContent is always going to be null, ensure that you deserialize " +
+            $"the special \"{typeof(NoContent).FullName}\" type. This type can always be deserialized, even " +
+            $"if no HttpContent is given.";
 
         #endregion
 


### PR DESCRIPTION
## What does this PR change?
* Added the `DeserializeWithoutHttpContentAsync` method to the `HttpContentSerializer`. By default, this method throws an exception. Deriving classes can override this method to control the default behavior.
* Updated a lot of exception strings to give more context.

## Followup tasks
<!-- Required. Check all boxes that apply. -->
- [x] The tests must be updated to reflect these changes (if not already done in this PR).
- [ ] The `CHANGELOG.md` must be updated with the changes in the PR (if not already done in this PR).
- [x] The documentation must be updated to reflect these changes.

## Additional Information
_None._

## Open Tasks
<!-- Optional. Tasks to be done BEFORE the PR will be merged. -->
_None._

## Open Questions
<!-- Optional. Open points to be discussed in the comments. -->
_None._
