### PR TITLE
Removed the DeserializeWithoutHttpContentAsync method and the public virtual suffixes from the HttpContentSerializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,10 @@
 * **[Breaking]** The `IHttpContentSerializer.Serialize` method has been extended with the `Type contentType` parameter that allows users to specify the type of the object to be serialized.
 * **[Breaking]** The `HttpContentSerializer` implements these interface changes.
 * **[Breaking]** Renamed `HttpContentSerializer.DeserializeCore` to `DeserializeAsyncCore`.
+* **[Breaking]** The `HttpContentSerializer.DeserializeCore` method's `HttpContent` parameter is now nullable.
 * **[Breaking]** Renamed `SetContent(byte[], ...)` to `SetByteArrayContent`.
 * **[Breaking]** Renamed `SetContent(string, ...)` to `SetStringContent`.
 * **[Breaking]** The `UriBuilderExtensions.AppendPath(string? path)` method no longer appends a trailing `/` if `path` is `null` or empty.
-* Added the `DeserializeWithoutHttpContentAsync` method to the `HttpContentSerializer` to allow changing the default deserialization behavior if no HttpContent is given.
 * Added new `SetContent(IHttpContentSerializer, ...)` overloads to the `HttpContentBuilderExtensions`.
 * Added the optional `UriKind uriKind = UriKind.RelativeOrAbsolute` parameter to `RequestUriBuilderExtensions.SetRequestUri(IRequestUriBuilder, string)`.
 * Several methods like `ApiResponse{T}.DeserializeResourceAsync` now support an additional `CancellationToken` parameter.

--- a/src/ReqRest.Serializers.Json/JsonHttpContentSerializer.cs
+++ b/src/ReqRest.Serializers.Json/JsonHttpContentSerializer.cs
@@ -95,7 +95,7 @@
 
         /// <inheritdoc/>
         protected override async Task<object?> DeserializeAsyncCore(
-            HttpContent httpContent, Type contentType, CancellationToken cancellationToken)
+            HttpContent? httpContent, Type contentType, CancellationToken cancellationToken)
         {
             // While we'd ideally read directly from the stream here (if UTF-8), this is a lot of messy work.
             // For one, we don't know if the encoding is UTF-8 and finding this out is hard to do
@@ -104,7 +104,7 @@
             // For the moment, simply fall back to simple string deserialization and optimize this later,
             // if required.
             // If this is an absolute must, people can still derive from this class and override the method.
-            var json = await httpContent.ReadAsStringAsync().ConfigureAwait(false);
+            var json = httpContent is null ? "" : await httpContent.ReadAsStringAsync().ConfigureAwait(false);
             return JsonSerializer.Deserialize(json, contentType, JsonSerializerOptions);
         }
 

--- a/src/ReqRest.Serializers.NewtonsoftJson.Tests/JsonBuilderExtensionsTests.cs
+++ b/src/ReqRest.Serializers.NewtonsoftJson.Tests/JsonBuilderExtensionsTests.cs
@@ -13,6 +13,7 @@
     using Xunit;
     using ReqRest.Tests.Sdk.Models;
     using ReqRest.Serializers.NewtonsoftJson.Tests.TestData;
+    using Moq.Protected;
 
     public class JsonBuilderExtensionsTests
     {
@@ -98,7 +99,7 @@
                 var dto = new SerializationDto();
 
                 Service.SetJsonContent(dto, Encoding.ASCII, serializerMock.Object);
-                serializerMock.Verify(x => x.Serialize(dto, typeof(SerializationDto), Encoding.ASCII));
+                serializerMock.Protected().Verify("SerializeCore", Times.Once(), dto, typeof(SerializationDto), Encoding.ASCII);
             }
 
         }

--- a/src/ReqRest.Serializers.NewtonsoftJson/JsonHttpContentSerializer.cs
+++ b/src/ReqRest.Serializers.NewtonsoftJson/JsonHttpContentSerializer.cs
@@ -100,9 +100,9 @@
 
         /// <inheritdoc/>
         protected override async Task<object?> DeserializeAsyncCore(
-            HttpContent httpContent, Type contentType, CancellationToken cancellationToken)
+            HttpContent? httpContent, Type contentType, CancellationToken cancellationToken)
         {
-            var json = await httpContent.ReadAsStringAsync().ConfigureAwait(false);
+            var json = httpContent is null ? "" : await httpContent.ReadAsStringAsync().ConfigureAwait(false);
             using var stringReader = new StringReader(json);
             using var jsonReader = new JsonTextReader(stringReader);
             return ActualJsonSerializer.Deserialize(jsonReader, contentType);

--- a/src/ReqRest.Tests.Sdk/Mocks/Dummy.cs
+++ b/src/ReqRest.Tests.Sdk/Mocks/Dummy.cs
@@ -33,7 +33,7 @@
             }
 
             var mockUsingAttribute = parameter.GetCustomAttribute<MockUsingAttribute>();
-            if (mockUsingAttribute != null)
+            if (!(mockUsingAttribute is null))
             {
                 return mockUsingAttribute.GetMockDataProvider().Create();
             }

--- a/src/ReqRest.Tests/Builders/TestRecipes/AddHeaderExtensionRecipe.cs
+++ b/src/ReqRest.Tests/Builders/TestRecipes/AddHeaderExtensionRecipe.cs
@@ -68,7 +68,7 @@
             AddHeader(Builder, name, values);
             Assert.Contains(Builder.Headers, header =>
                 header.Key == name &&
-                (values == null || !values.Where(v => v != null).Any())
+                (values == null || !values.Where(v => !(v is null)).Any())
                     ? header.Value.SequenceEqual(new string[] { "" })
                     : header.Value.SequenceEqual(values)
             );

--- a/src/ReqRest.Tests/Builders/TestRecipes/SetHeaderExtensionRecipe.cs
+++ b/src/ReqRest.Tests/Builders/TestRecipes/SetHeaderExtensionRecipe.cs
@@ -73,7 +73,7 @@
 
             Assert.Contains(Builder.Headers, header =>
                 header.Key == name &&
-                (values == null || !values.Where(v => v != null).Any())
+                (values == null || !values.Where(v => !(v is null)).Any())
                     ? header.Value.SequenceEqual(new string[] { "" })
                     : header.Value.SequenceEqual(values)
             );

--- a/src/ReqRest/ApiResponseBase.cs
+++ b/src/ReqRest/ApiResponseBase.cs
@@ -70,7 +70,7 @@
         private protected bool CanDeserializeResource<T>()
         {
             var currentResponseTypeInfo = GetCurrentResponseTypeInfo();
-            return currentResponseTypeInfo != null
+            return !(currentResponseTypeInfo is null)
                 && typeof(T).IsAssignableFrom(currentResponseTypeInfo.ResponseType);
         }
 

--- a/src/ReqRest/Builders/HttpHeadersBuilderExtensions.ContentHeaders.cs
+++ b/src/ReqRest/Builders/HttpHeadersBuilderExtensions.ContentHeaders.cs
@@ -42,7 +42,7 @@
             };
 
             // It sucks that the parameters cannot be set directly. This only leaves enumeration.
-            if (parameters != null)
+            if (!(parameters is null))
             {
                 foreach (var param in parameters)
                 {

--- a/src/ReqRest/Builders/HttpRequestPropertiesBuilderExtensions.cs
+++ b/src/ReqRest/Builders/HttpRequestPropertiesBuilderExtensions.cs
@@ -95,7 +95,7 @@
             {
                 foreach (var name in names)
                 {
-                    if (name != null)
+                    if (!(name is null))
                     {
                         p.Remove(name);
                     }

--- a/src/ReqRest/Builders/UriBuilderExtensions.cs
+++ b/src/ReqRest/Builders/UriBuilderExtensions.cs
@@ -304,7 +304,7 @@
         {
             _ = builder ?? throw new ArgumentNullException(nameof(builder));
 
-            if (parameters != null)
+            if (!(parameters is null))
             {
                 foreach (var param in parameters)
                 {

--- a/src/ReqRest/Internal/HttpHeadersExtensions.cs
+++ b/src/ReqRest/Internal/HttpHeadersExtensions.cs
@@ -44,7 +44,7 @@
 
             foreach (var name in names)
             {
-                if (name != null)
+                if (!(name is null))
                 {
                     headers.Remove(name);
                 }

--- a/src/ReqRest/Resources/ExceptionStrings.cs
+++ b/src/ReqRest/Resources/ExceptionStrings.cs
@@ -91,14 +91,6 @@
             $"The content to be serialized does not match the specified type. " +
             $"Expected an instance of the class \"${expected.FullName}\", but got \"{actual.FullName}\".";
 
-        public static string HttpContentSerializer_HttpContentIsNull(Type contentType) =>
-            $"The HttpContent to be deserialized into an object of type \"{contentType.FullName}\" " +
-            $"was null (Nothing in VB). An HttpContent which is null cannot be deserialized by this " +
-            $"serializer.\n" +
-            $"If you know that the HttpContent is always going to be null, ensure that you deserialize " +
-            $"the special \"{typeof(NoContent).FullName}\" type. This type can always be deserialized, even " +
-            $"if no HttpContent is given.";
-
         #endregion
 
     }


### PR DESCRIPTION
## What does this PR change?
<!-- Required. -->
- Removed the DeserializeWithoutHttpContentAsync method in favor of the single DeserializeAsyncCore method.
- Updated the DeserializeAsyncCore method to accept a nullable HttpContent?.
- Updated the JsonHttpContentSerializers to treat a null HttpContent as an empty content.
- Removed the virtual modifier from the Serialize and DeserializeAsync methods in the HttpContentSerializer.

Code Style Fixes:
- Updated all occurences of (x != null) to use !(x is null) to ensure consistency with the generally used (x is null) style.


## Followup tasks
<!-- Required. Check all boxes that apply. -->
- [ ] The tests must be updated to reflect these changes (if not already done in this PR).
- [ ] The `CHANGELOG.md` must be updated with the changes in the PR (if not already done in this PR).
- [x] The documentation must be updated to reflect these changes.

## Additional Information
<!-- Optional. Any information describing the issue. -->
_None._

## Open Tasks
<!-- Optional. Tasks to be done BEFORE the PR will be merged. -->
_None._

## Open Questions
<!-- Optional. Open points to be discussed in the comments. -->
_None._
